### PR TITLE
Imagemagick@6 6.9.7 4

### DIFF
--- a/Formula/imagemagick@6.rb
+++ b/Formula/imagemagick@6.rb
@@ -10,7 +10,7 @@ class ImagemagickAT6 < Formula
 
   bottle do
     root_url "https://s3.amazonaws.com/crazymykl"
-    sha256 "136abfca8cefa8c7071a7f56e32bcd4064c05a5e8104ce9bc9d8a145273a48a6" => :sierra
+    sha256 "bd97a2995994ff4a802f63a7bb97e707914345d1adcea5d7a58220d097dba84d" => :sierra
   end
 
   option "with-fftw", "Compile with FFTW support"

--- a/Formula/imagemagick@6.rb
+++ b/Formula/imagemagick@6.rb
@@ -4,9 +4,9 @@ class ImagemagickAT6 < Formula
   # Please always keep the Homebrew mirror as the primary URL as the
   # ImageMagick site removes tarballs regularly which means we get issues
   # unnecessarily and older versions of the formula are broken.
-  url "https://s3.amazonaws.com/crazymykl/ImageMagick-6.9.7-3.tar.xz"
-  mirror "https://www.imagemagick.org/download/ImageMagick-6.9.7-3.tar.xz"
-  sha256 "801767344b835b810a5f88c26f062f0fa01a97264dfe9bf5e5adf59a0b5c91a1"
+  url "https://s3.amazonaws.com/crazymykl/ImageMagick-6.9.7-4.tar.xz"
+  mirror "https://www.imagemagick.org/download/ImageMagick-6.9.7-4.tar.xz"
+  sha256 "68842c55ed9c958b84aae17974961cefff4212bf7146f09fd15c09dbdc2d9629"
 
   bottle do
     root_url "https://s3.amazonaws.com/crazymykl"


### PR DESCRIPTION
Upgrade to 6.9.7-4.

Split up with the bottle metadata added in the 2nd commit. Not sure whether you wanted to build this yourself, but if not, the bottle is as listed below.

* Original source tarball (in case original is removed) at https://www.dropbox.com/s/19jrhn0fsv4f9ku/ImageMagick-6.9.7-4.tar.xz?dl=0
* Built bottle at https://www.dropbox.com/s/ge24zyfwxa2szr7/imagemagick%406-6.9.7-4.sierra.bottle.tar.gz?dl=0